### PR TITLE
denote branch in Operating Agreement definition

### DIFF
--- a/documents/operating.md
+++ b/documents/operating.md
@@ -22,9 +22,9 @@ SECTION 0: 📓📓📓 Definitions 📓📓📓
 * The "**Hive Mind**" shall mean the "board of directors" of the Company, as defined by Pennsylvania state law. The Hive Mind shall consist of all current Corporate Overlords of the Company.
 * "**Plotting Session**" shall mean a meeting of the "board of directors" of the Company, as defined by Pennsylvania state law.
 * "**Quorum**" shall mean the presence of 2/3 or more of the company's Corporate Overlords.
-* "Operating Agreement" shall refer to the official version of this document
+* "**Operating Agreement**" shall refer to the official version of this document
 to be held in a file named `operating.md` in the `documents` directory of the
-`corporate` repository within the `BadIdeaFactory` team hosted on GitHub.
+`master` branch of the `corporate` repository within the `BadIdeaFactory` team hosted on GitHub. (As of July 2017, the described version of the file may be located at: https://github.com/BadIdeaFactory/corporate/blob/master/documents/operating.md )
 
 ### Support Categories
 * "**Complete Consensus**" shall mean 100% support or more.


### PR DESCRIPTION
Also URL to canonical version of Operating Agreement, as defined. I'm back and forth on the idea of putting in that URL as a point of reference, but _feel like_ something like that should be there. But like if this were a normal type of document, I'd make that parenthetical statement a footnote; dunno if there's a better way to similarly include it as an aside here.