### PR TITLE
2017 / 2018 Plotting Sessions

### DIFF
--- a/records/meeting_schedule.md
+++ b/records/meeting_schedule.md
@@ -1,0 +1,19 @@
+# Meeting Ledger
+
+## Upcoming Plotting Sessions
+
+- Sunday, October 8th, 2017 at 12:00 PM EST
+- Saturday, November 4th, 2017 at 12:00 PM EST
+- Saturday, December 2nd, 2017 at 12:00 PM EST
+- Saturday, January 6th, 2017 at 12:00 PM EST
+- Saturday, February 3rd, 2017 at 12:00 PM EST
+- Saturday, March 3rd, 2017 at 12:00 PM EST
+- Sunday, April 1st, 2017 at 12:00 PM EST
+
+## Implanted Memories
+
+The following plotting sessions occurred in the past, assuming we trust our
+memories.
+
+### 2017 Memories
+- Thursday, August 31st, 2017 at 9:00 PM EST (minutes TBD)


### PR DESCRIPTION
As per the bylaws, the plotting sessions must be announced in advance.
This schedule will take us to the end of the first term, and also
includes our April Fools plotting session.