### PR TITLE
Revise IP approval clause for GPL-compatible licenses

### DIFF
--- a/documents/operating.md
+++ b/documents/operating.md
@@ -245,7 +245,7 @@ This dictation of petty cash does not apply to projects that were approved befor
 ### Intellectual Property/Internet Protocol
 The following numbered clauses apply to all BIFFUD projects unless explicitly approved otherwise by the Corporate Overlords during project approval or at a later date during a Plotting Session.
 
-1. Everything contributed to a BIFFUD project must be developed in the open and licensed under the Apache License, Version 2.0. A Project may use another license by approval of Majority of the Corporate Overlords (for example, if another license is necessary for the purposes of fulfilling third party funding requirements, or if a copyleft license better suits the goals of the Project).
+1. Everything contributed to a BIFFUD project must be developed in the open and licensed under the Apache License, Version 2.0. If a Project has a license restriction imposed by a third party, the license shall be deemed acceptable without further approval if the license is a GPL-compatible license, as defined by the [Free Software Foundation's list of GPL-Compatible Free Software Licenses](https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses). In all other situations, a Project may use another license by approval of Majority of the Corporate Overlords.
 
 2. All BIFFUD projects must have the language written in `documents/federated_contributing.md` inserted into a CONTRIBUTING.md file at the root level of the project unless explicitly approved otherwise by the Corporate Overlords during project approval or at a later date during a Plotting Session.
 


### PR DESCRIPTION
Our current bylaws specify that BIFFUD projects must use the Apache Software License Version 2.0, with the requirement that any alternative licenses must be approved by a majority of Corporate Overlords. Hot take: the spirit of this clause is to encourage us to do open source work, rather than to make a political statement about which open source license is the “most correct” one. Yet a strict interpretation of this bylaw would be that there is only One True License, and introduce an additional approval requirement for projects with other permissive open source licenses that are not specifically the Apache License Version 2.0, placing these other permissive licenses under the same level of scrutiny as non-permissive (e.g. “copyleft” licenses).

This revision removes the approval requirement when the project has a license imposed by a third-party, if the license is recognized by the open-source community as a permissive open-source license (“GPL-compatible”).

I preserve the intent for BIFFUD projects to adopt the standard “default” license (Apache License Version 2.0), rather than allow projects owners to choose a-la-carte.