### PR TITLE
Add one, and correct another, link to the bylaws

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-application.md
+++ b/.github/ISSUE_TEMPLATE/project-application.md
@@ -5,10 +5,11 @@ about: Propose a new BIFFUD project
 ---
 
 # I HEREBY INVOKE MY RIGHTS...
-As described in section 11.11.B of the BIFFUD Corporate Bylaws I hereby invoke
-my rights as a sentient being who has not uploaded their mind to the cloud for consideration of this project application by the BIFFUD Hive Mind.  With this
-application I submit my interest in becoming a Member of BIFFUD and having this
-project supported and adored by all who can 🤔.
+As described in section 11.11.B of the BIFFUD [Corporate Bylaws] I hereby
+invoke my rights as a sentient being who has not uploaded their mind to the
+cloud for consideration of this project application by the BIFFUD Hive Mind.
+With this application I submit my interest in becoming a Member of BIFFUD and
+having this project supported and adored by all who can 🤔.
 
 ## Project Information
 - Project Name: [Project Name]
@@ -60,3 +61,5 @@ with the project.  Must also be listed in previous section.]
 ### How (often) will you be providing updates to the organization?
 [Ideas are great, action is better!  How often should we expect you
 to be able to make progress? How would you like to report back]
+
+[Corporate Bylaws]: https://github.com/BadIdeaFactory/corporate/blob/master/documents/operating.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This document contains information of use to partners looking to
 improve the BIFFUD's corporate documentation.  See [README.md](README.md)
 for a sense of the purpose of this repository.
 
-You should also look at the [Corporate Bylaws](documents/OPERATING.md)
+You should also look at the [Corporate Bylaws](documents/operating.md)
 which lays out some of the processes around the repository.
 
 ## Baseline Concepts


### PR DESCRIPTION
## Why

The issue template for project applications referred to the existence of BIFFUD's corporate bylaws, but did not link to them.

This might have been intentional, to require people to search for the bylaws. Searchers had a mighty quest set before them, for the the bylaws links contained in this repository pointed to the wrong filename. The correct file, `documents/operating.md`, was often mentioned without naming it as the Bylaws. It's a twisty puzzle for would-be contributors.

![Detective Pikachu holds up a magnifying glass, saying, "That's very twisty."](https://gifs.benlk.com/twisty.gif).

## Changes

This PR adds a bylaws link to the project-application issue template. This PR also fixes a broken link in `CONTRIBUTING.md` to the bylaws, which used the wrong case for the filename.

## Why you should merge this:

- Makes it easier to contribute
- Broken links are bad
- Reduces confusion

## Why you should not merge this:

- This reduces the difficulty level for contributing, making it more likely that contributors will not have gone on an exhaustive, character-building quest to learn the secret method of contributing, which was inside their hearts all along.

## Additional matters

- Consider adding "bylaws" in a heading-level element in `/documents/operating.md`
- Maybe link to bylaws from `/README.md`?
- Should there be a minimal pull request template?