### PR TITLE
returning COs + capital contributions for returning COs

### DIFF
--- a/documents/operating.md
+++ b/documents/operating.md
@@ -106,6 +106,10 @@ Corporate Overlords may also vote to remove a peer from the organization if any 
 
 The removal of a corporate overlord can be nominated during a plotting session and the vote must pass as defined in Section 5.
 
+### Revenge of the Corporate Overlords
+
+A former Corporate Overlord who previously left BIFFUD through one of the *voluntary* methods described under "**Removing Corporate Overlords**" (as opposed to removal via a vote of Corporate Overlords, or removal via breach of other rules in this Operating Agreement), may return to the company anew only via the full ritual described in "**Adding Corporate Overlords**."
+
 ### Hibernating Corporate Overlords
 A Corporate Overlord can go into hibernation.  Hibernation does not remove their ownership of BIFFUD or their entitlement to profit share, but their role as a voting member of the Hive is temporarily revoked until they attend a plotting session.
 
@@ -269,6 +273,10 @@ as described in Section 5. Contribution increases are retroactive and Corporate
 Overlords have three months to cough up the extra dough.
 
 Failure to contribute in a timely manner shall result in revocation of Corporate Overlord status.
+
+A former Corporate Overlord, returning to BIFFUD as described in Section 2 ->
+"**Revenge of the Corporate Overlords**," may have the capital contribution
+requirement waived via a vote of the Hive Mind.
 
 ### Third Party Contributions
 Third parties can give money to BIFFUD as a non-deductible donation or grant.


### PR DESCRIPTION
per some converations with @slifty: apparently no refund of equity/capital contribution currently happens if a Corporate Overlord leaves (since there are no provisions for it in the operating agreement). this PR / proposed operating agreement update is not actually about that.

i think the key part of the actual change here is the second block: the addition to the "Capital Contributions" section, where the Hive Mind can vote to waive a repeat capital contribution under specific circumstances.

(if we were to later add something about returning someone's equity or even just the capital contribution part, then we'd want to tweak that addition to the "Capital Contributions" section.)